### PR TITLE
Added checks for wav recorder state to ensure they stay in sync

### DIFF
--- a/src/pages/ConsolePage.tsx
+++ b/src/pages/ConsolePage.tsx
@@ -228,9 +228,13 @@ export function ConsolePage() {
    * .appendInputAudio() for each sample
    */
   const startRecording = async () => {
+    const wavRecorder = wavRecorderRef.current;
+    if (wavRecorder.getStatus() === 'recording') {
+      stopRecording();
+      return;
+    }
     setIsRecording(true);
     const client = clientRef.current;
-    const wavRecorder = wavRecorderRef.current;
     const wavStreamPlayer = wavStreamPlayerRef.current;
     const trackSampleOffset = await wavStreamPlayer.interrupt();
     if (trackSampleOffset?.trackId) {
@@ -247,8 +251,10 @@ export function ConsolePage() {
     setIsRecording(false);
     const client = clientRef.current;
     const wavRecorder = wavRecorderRef.current;
-    await wavRecorder.pause();
-    client.createResponse();
+    if (wavRecorder.getStatus() === 'recording') {
+      await wavRecorder.pause();
+      client.createResponse();
+    }
   };
 
   /**


### PR DESCRIPTION
Issue:
In the manual PTT mode it is possible for the button to get into an incorrect state, throwing an error on the page.

Added checks for ensuring the wav recorder state and the page state are in sync. Calling .record() when already recording and .pause() while already paused causes errors. 

Reproduction:
The error is reproducible if the user moves their mouse cursor off the manual PTT button after pressing it (Mouse Down over button -> move mouse off of button -> release mouse, the screen will stay recording). Clicking the button again will cause an error as the wav recorder is still recording from before.

Fix:
Check the state before calling operations on the wav recorder.