### PR TITLE
allow for client side key to be used with relay server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ It will start automatically on `localhost:8081`.
 REACT_APP_LOCAL_RELAY_SERVER_URL=http://localhost:8081
 ```
 
-The `.env` file also needs to either contain an OpenAI API key or specify that the client should provide the API key.
+When using the relay server, the `.env` file also needs to either contain an OpenAI API key or specify that the client should provide the API key.
 
 To use an OpenAI API key, add the following line to your `.env` file:
 
@@ -86,7 +86,7 @@ To use an OpenAI API key, add the following line to your `.env` file:
 OPENAI_API_KEY=YOUR_API_KEY
 ```
 
-To use the client API key, add the following line to your `.env file:
+To use the client API key while using the relay server, add the following line to your `.env file:
 
 ```conf
 REACT_APP_USE_CLIENT_API_KEY=true

--- a/README.md
+++ b/README.md
@@ -72,11 +72,24 @@ $ npm run relay
 
 It will start automatically on `localhost:8081`.
 
-**You will need to create a `.env` file** with the following configuration:
+**You will need to create a `.env` file** with the relay server URL specified:
+
+```conf
+REACT_APP_LOCAL_RELAY_SERVER_URL=http://localhost:8081
+```
+
+The `.env` file also needs to either contain an OpenAI API key or specify that the client should provide the API key.
+
+To use an OpenAI API key, add the following line to your `.env` file:
 
 ```conf
 OPENAI_API_KEY=YOUR_API_KEY
-REACT_APP_LOCAL_RELAY_SERVER_URL=http://localhost:8081
+```
+
+To use the client API key, add the following line to your `.env file:
+
+```conf
+REACT_APP_USE_CLIENT_API_KEY=true
 ```
 
 You will need to restart both your React app and relay server for the `.env.` changes

--- a/relay-server/index.js
+++ b/relay-server/index.js
@@ -3,16 +3,17 @@ import dotenv from 'dotenv';
 dotenv.config({ override: true });
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const USE_CLIENT_API_KEY = process.env.REACT_APP_USE_CLIENT_API_KEY === 'true';
 
-if (!OPENAI_API_KEY) {
+if (!USE_CLIENT_API_KEY && !OPENAI_API_KEY) {
   console.error(
-    `Environment variable "OPENAI_API_KEY" is required.\n` +
-      `Please set it in your .env file.`
+    `Environment variable "OPENAI_API_KEY" is required when not using client API key.\n` +
+      `Please set it in your .env file or set USE_CLIENT_API_KEY=true.`
   );
   process.exit(1);
 }
 
 const PORT = parseInt(process.env.PORT) || 8081;
 
-const relay = new RealtimeRelay(OPENAI_API_KEY);
+const relay = new RealtimeRelay(OPENAI_API_KEY, USE_CLIENT_API_KEY);
 relay.listen(PORT);

--- a/relay-server/index.js
+++ b/relay-server/index.js
@@ -7,8 +7,8 @@ const USE_CLIENT_API_KEY = process.env.REACT_APP_USE_CLIENT_API_KEY === 'true';
 
 if (!USE_CLIENT_API_KEY && !OPENAI_API_KEY) {
   console.error(
-    `Environment variable "OPENAI_API_KEY" is required when not using client API key.\n` +
-      `Please set it in your .env file or set USE_CLIENT_API_KEY=true.`
+    `Environment variable "OPENAI_API_KEY" is required when not using a client API key.\n` +
+      `Please set it in your .env file or set REACT_APP_USE_CLIENT_API_KEY=true.`
   );
   process.exit(1);
 }


### PR DESCRIPTION
For my use case I'd like to be able to have the console client specify an API key while using a relay server without the relay server needing a hard-coded API key to use. This change is backwards compatible and requires an additional env var to be added to change the behavior, as documented in the updated README. The only item I'd flag is the relay server is referencing the same `REACT_APP` prefixed env var as the frontend which isn't standard for server code but I opted for this instead of using two different redundant env vars. An alternative would be that the relay server checks request headers for a key, and implicitly uses the presence of a key to use that instead of requiring a key provided via the env var, although for now I opted for the more explicit approach. 

Please let me know if there is any feedback and I can make adjustments. I'm hoping to get this in so I can otherwise keep my forked code updated with any more changes that are made on the base branch.

