### PR TITLE
fix: The log method in debug mode makes a recurring call

### DIFF
--- a/src/lib/wavtools/lib/wav_recorder.js
+++ b/src/lib/wavtools/lib/wav_recorder.js
@@ -136,7 +136,7 @@ export class WavRecorder {
    */
   log() {
     if (this.debug) {
-      this.log(...arguments);
+      console.log(...arguments);
     }
     return true;
   }


### PR DESCRIPTION
The original `this.log()` method calls itself in a loop
Use the `console.log()` method to avoid the loop.