### PR TITLE
stop audio capture when session closed

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -64,6 +64,12 @@ export default function App() {
     if (dataChannel) {
       dataChannel.close();
     }
+    peerConnection.current.getSenders().forEach(sender => {
+      if (sender.track) {
+        sender.track.stop();
+      }
+    });
+    
     if (peerConnection.current) {
       peerConnection.current.close();
     }


### PR DESCRIPTION
currently when user clicked stop session, the microphone is still working, we need to stop that.