### PR TITLE
fix: preserve original event timestamps

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -83,8 +83,16 @@ export default function App() {
   // Send a message to the model
   function sendClientEvent(message) {
     if (dataChannel) {
+      const timestamp = new Date().toLocaleTimeString();
       message.event_id = message.event_id || crypto.randomUUID();
+
+      // send event before setting timestamp since the backend peer doesn't expect this field
       dataChannel.send(JSON.stringify(message));
+
+      // if guard just in case the timestamp exists by miracle
+      if (!message.timestamp) {
+        message.timestamp = timestamp;
+      }
       setEvents((prev) => [message, ...prev]);
     } else {
       console.error(
@@ -119,7 +127,12 @@ export default function App() {
     if (dataChannel) {
       // Append new server events to the list
       dataChannel.addEventListener("message", (e) => {
-        setEvents((prev) => [JSON.parse(e.data), ...prev]);
+        const event = JSON.parse(e.data);
+        if (!event.timestamp) {
+          event.timestamp = new Date().toLocaleTimeString();
+        }
+
+        setEvents((prev) => [event, ...prev]);
       });
 
       // Set session active when the data channel is opened

--- a/client/components/EventLog.jsx
+++ b/client/components/EventLog.jsx
@@ -48,11 +48,7 @@ export default function EventLog({ events }) {
     }
 
     eventsToDisplay.push(
-      <Event
-        key={event.event_id}
-        event={event}
-        timestamp={new Date().toLocaleTimeString()}
-      />,
+      <Event key={event.event_id} event={event} timestamp={event.timestamp} />,
     );
   });
 


### PR DESCRIPTION
fix issue where timestamps would update on each re-render by adding timestamp to events when they are created/received instead of render time