### PR TITLE
Add real-time translation mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an example application demonstrating the OpenAI Realtime API with WebRTC. It enables real-time voice conversations with OpenAI's GPT models using browser microphone input and audio output.
+
+## Commands
+
+- `npm run dev` - Start development server with hot reload (runs on port 3000)
+- `npm run build` - Build both client and server for production
+- `npm run lint` - Run ESLint with auto-fix on .js and .jsx files
+
+## Architecture
+
+### Server (server.js)
+Express server that:
+- Serves the React frontend via Vite middleware (SSR-enabled)
+- Provides `/token` endpoint to generate ephemeral OpenAI API keys for client-side WebRTC connections
+- Provides `/session` endpoint for experimental all-in-one SDP exchange
+
+### Client (client/)
+React 18 application using Vite with SSR support:
+
+- **entry-client.jsx / entry-server.jsx** - SSR hydration entry points
+- **components/App.jsx** - Main component managing WebRTC connection lifecycle
+  - Handles peer connection setup, audio tracks, and data channel
+  - Uses `/token` endpoint for ephemeral keys, then connects directly to OpenAI's Realtime API
+- **components/EventLog.jsx** - Displays Realtime API events (with delta event deduplication)
+- **components/SessionControls.jsx** - Start/stop session and send text messages
+- **components/ToolPanel.jsx** - Example of client-side function calling (color palette tool)
+
+### WebRTC Flow
+1. Client fetches ephemeral token from `/token`
+2. Creates RTCPeerConnection with audio track from getUserMedia
+3. Creates data channel "oai-events" for Realtime API events
+4. Exchanges SDP offer/answer with OpenAI's `/v1/realtime/calls` endpoint
+5. All Realtime API events flow through the data channel as JSON
+
+### Configuration
+- Requires `OPENAI_API_KEY` in `.env` file
+- Vite config roots from `client/` directory
+- Uses Tailwind CSS for styling

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,35 +1,85 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "react-feather";
 import logo from "/assets/openai-logomark.svg";
 import EventLog from "./EventLog";
 import SessionControls from "./SessionControls";
 import ToolPanel from "./ToolPanel";
+import ConversationTimeline from "./ConversationTimeline";
 
 export default function App() {
   const [isSessionActive, setIsSessionActive] = useState(false);
   const [events, setEvents] = useState([]);
   const [dataChannel, setDataChannel] = useState(null);
   const peerConnection = useRef(null);
-  const audioElement = useRef(null);
+  const mediaStream = useRef(null);
+
+  // Translation app state
+  const [translations, setTranslations] = useState([]);
+  const [languageA, setLanguageA] = useState("English");
+  const [languageB, setLanguageB] = useState("Korean");
+  const [inputMode, setInputMode] = useState("vad");
+  const [isRecording, setIsRecording] = useState(false);
+  const [apiKey, setApiKey] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("openai-api-key") || "";
+    }
+    return "";
+  });
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [isEditingKey, setIsEditingKey] = useState(false);
+
+  // Persist API key to localStorage
+  useEffect(() => {
+    if (apiKey) {
+      localStorage.setItem("openai-api-key", apiKey);
+    }
+  }, [apiKey]);
 
   async function startSession() {
-    // Get a session token for OpenAI Realtime API
-    const tokenResponse = await fetch("/token");
+    if (!apiKey) {
+      alert("Please enter your OpenAI API key");
+      return;
+    }
+
+    // Get a transcription session token
+    const turnDetection = inputMode === "vad" ? "server_vad" : "none";
+    const tokenResponse = await fetch(`/token?turnDetection=${turnDetection}`, {
+      headers: { "X-API-Key": apiKey },
+    });
     const data = await tokenResponse.json();
-    const EPHEMERAL_KEY = data.value;
+    console.log("Token response:", data);
+
+    if (data.error) {
+      console.error("API error:", data.error);
+      alert(`API Error: ${data.error.message || data.error}`);
+      throw new Error(data.error.message || "API error");
+    }
+
+    const EPHEMERAL_KEY = data.client_secret?.value || data.value;
+    console.log("Ephemeral key prefix:", EPHEMERAL_KEY?.substring(0, 10));
+
+    if (!EPHEMERAL_KEY) {
+      console.error("No ephemeral key in response:", data);
+      alert("Failed to get session token. Check your API key.");
+      throw new Error("Failed to get ephemeral key");
+    }
 
     // Create a peer connection
     const pc = new RTCPeerConnection();
 
-    // Set up to play remote audio from the model
-    audioElement.current = document.createElement("audio");
-    audioElement.current.autoplay = true;
-    pc.ontrack = (e) => (audioElement.current.srcObject = e.streams[0]);
-
-    // Add local audio track for microphone input in the browser
+    // Add local audio track for microphone input
     const ms = await navigator.mediaDevices.getUserMedia({
       audio: true,
     });
-    pc.addTrack(ms.getTracks()[0]);
+    mediaStream.current = ms;
+    const audioTrack = ms.getTracks()[0];
+
+    // For push-to-talk, start with track disabled
+    if (inputMode === "push-to-talk") {
+      audioTrack.enabled = false;
+    }
+
+    pc.addTrack(audioTrack);
 
     // Set up data channel for sending and receiving events
     const dc = pc.createDataChannel("oai-events");
@@ -38,6 +88,7 @@ export default function App() {
     // Start the session using the Session Description Protocol (SDP)
     const offer = await pc.createOffer();
     await pc.setLocalDescription(offer);
+    console.log("Offer SDP (first 200 chars):", offer.sdp.substring(0, 200));
 
     const baseUrl = "https://api.openai.com/v1/realtime/calls";
     const model = "gpt-realtime";
@@ -50,7 +101,16 @@ export default function App() {
       },
     });
 
-    const sdp = await sdpResponse.text();
+    const sdpText = await sdpResponse.text();
+    console.log("SDP response status:", sdpResponse.status);
+    console.log("SDP response:", sdpText.substring(0, 500));
+
+    if (!sdpResponse.ok) {
+      console.error("SDP exchange failed:", sdpResponse.status, sdpText);
+      throw new Error(`SDP exchange failed: ${sdpResponse.status}`);
+    }
+
+    const sdp = sdpText;
     const answer = { type: "answer", sdp };
     await pc.setRemoteDescription(answer);
 
@@ -63,11 +123,10 @@ export default function App() {
       dataChannel.close();
     }
 
-    peerConnection.current.getSenders().forEach((sender) => {
-      if (sender.track) {
-        sender.track.stop();
-      }
-    });
+    if (mediaStream.current) {
+      mediaStream.current.getTracks().forEach((track) => track.stop());
+      mediaStream.current = null;
+    }
 
     if (peerConnection.current) {
       peerConnection.current.close();
@@ -76,7 +135,73 @@ export default function App() {
     setIsSessionActive(false);
     setDataChannel(null);
     peerConnection.current = null;
+    setIsRecording(false);
   }
+
+  // Handle transcription by sending to translation API
+  const handleTranscription = useCallback(
+    async (transcript) => {
+      try {
+        const response = await fetch("/translate", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-API-Key": apiKey,
+          },
+          body: JSON.stringify({
+            text: transcript,
+            languageA,
+            languageB,
+          }),
+        });
+
+        const translation = await response.json();
+
+        // Determine speaker based on detected language
+        const speaker = translation.detectedLanguage === languageA ? "A" : "B";
+
+        const entry = {
+          id: crypto.randomUUID(),
+          timestamp: new Date().toISOString(),
+          speaker,
+          sourceText: translation.sourceText,
+          sourceLanguage: translation.detectedLanguage,
+          translatedText: translation.translatedText,
+          targetLanguage: translation.targetLanguage,
+        };
+
+        setTranslations((prev) => [...prev, entry]);
+      } catch (error) {
+        console.error("Translation failed:", error);
+      }
+    },
+    [languageA, languageB, apiKey],
+  );
+
+  // Push-to-talk controls
+  const startRecording = useCallback(() => {
+    if (mediaStream.current) {
+      mediaStream.current.getTracks()[0].enabled = true;
+      setIsRecording(true);
+    }
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    if (mediaStream.current) {
+      mediaStream.current.getTracks()[0].enabled = false;
+      setIsRecording(false);
+
+      // Commit the audio buffer to trigger transcription
+      if (dataChannel) {
+        const event = {
+          type: "input_audio_buffer.commit",
+          event_id: crypto.randomUUID(),
+        };
+        dataChannel.send(JSON.stringify(event));
+        setEvents((prev) => [{ ...event, timestamp: new Date().toLocaleTimeString() }, ...prev]);
+      }
+    }
+  }, [dataChannel]);
 
   // Send a message to the model
   function sendClientEvent(message) {
@@ -100,78 +225,135 @@ export default function App() {
     }
   }
 
-  // Send a text message to the model
-  function sendTextMessage(message) {
-    const event = {
-      type: "conversation.item.create",
-      item: {
-        type: "message",
-        role: "user",
-        content: [
-          {
-            type: "input_text",
-            text: message,
-          },
-        ],
-      },
-    };
-
-    sendClientEvent(event);
-    sendClientEvent({ type: "response.create" });
-  }
-
   // Attach event listeners to the data channel when a new one is created
   useEffect(() => {
     if (dataChannel) {
       // Append new server events to the list
-      dataChannel.addEventListener("message", (e) => {
+      const handleMessage = async (e) => {
         const event = JSON.parse(e.data);
         if (!event.timestamp) {
           event.timestamp = new Date().toLocaleTimeString();
         }
 
         setEvents((prev) => [event, ...prev]);
-      });
+
+        // Handle transcription completion events
+        if (
+          event.type === "conversation.item.input_audio_transcription.completed"
+        ) {
+          const transcript = event.transcript;
+          if (transcript && transcript.trim()) {
+            await handleTranscription(transcript);
+          }
+        }
+      };
 
       // Set session active when the data channel is opened
-      dataChannel.addEventListener("open", () => {
+      const handleOpen = () => {
         setIsSessionActive(true);
         setEvents([]);
-      });
+        setTranslations([]);
+      };
+
+      dataChannel.addEventListener("message", handleMessage);
+      dataChannel.addEventListener("open", handleOpen);
+
+      return () => {
+        dataChannel.removeEventListener("message", handleMessage);
+        dataChannel.removeEventListener("open", handleOpen);
+      };
     }
-  }, [dataChannel]);
+  }, [dataChannel, handleTranscription]);
 
   return (
     <>
       <nav className="absolute top-0 left-0 right-0 h-16 flex items-center">
-        <div className="flex items-center gap-4 w-full m-4 pb-2 border-0 border-b border-solid border-gray-200">
-          <img style={{ width: "24px" }} src={logo} />
-          <h1>realtime console</h1>
+        <div className="flex items-center justify-between w-full m-4 pb-2 border-0 border-b border-solid border-gray-200">
+          <div className="flex items-center gap-4">
+            <img style={{ width: "24px" }} src={logo} />
+            <h1>realtime translator</h1>
+          </div>
+          {apiKey && !isEditingKey && (
+            <button
+              onClick={() => setIsEditingKey(true)}
+              className="text-xs text-gray-400 hover:text-gray-600 px-2 py-1"
+            >
+              Edit API Key
+            </button>
+          )}
         </div>
       </nav>
       <main className="absolute top-16 left-0 right-0 bottom-0">
-        <section className="absolute top-0 left-0 right-[380px] bottom-0 flex">
-          <section className="absolute top-0 left-0 right-0 bottom-32 px-4 overflow-y-auto">
-            <EventLog events={events} />
+        {/* Main content area - ConversationTimeline */}
+        <section
+          className={`absolute top-0 left-0 bottom-0 flex flex-col transition-all duration-300 ${
+            sidebarCollapsed ? "right-0" : "right-[380px]"
+          }`}
+        >
+          <section className="flex-1 overflow-hidden">
+            <ConversationTimeline
+              translations={translations}
+              languageA={languageA}
+              languageB={languageB}
+            />
           </section>
-          <section className="absolute h-32 left-0 right-0 bottom-0 p-4">
+          <section className="h-32 p-4">
             <SessionControls
               startSession={startSession}
               stopSession={stopSession}
-              sendClientEvent={sendClientEvent}
-              sendTextMessage={sendTextMessage}
-              events={events}
               isSessionActive={isSessionActive}
+              languageA={languageA}
+              setLanguageA={setLanguageA}
+              languageB={languageB}
+              setLanguageB={setLanguageB}
+              inputMode={inputMode}
+              setInputMode={setInputMode}
+              isRecording={isRecording}
+              startRecording={startRecording}
+              stopRecording={stopRecording}
+              apiKey={apiKey}
+              setApiKey={setApiKey}
+              isEditingKey={isEditingKey}
+              setIsEditingKey={setIsEditingKey}
             />
           </section>
         </section>
-        <section className="absolute top-0 w-[380px] right-0 bottom-0 p-4 pt-0 overflow-y-auto">
-          <ToolPanel
-            sendClientEvent={sendClientEvent}
-            sendTextMessage={sendTextMessage}
-            events={events}
-            isSessionActive={isSessionActive}
-          />
+
+        {/* Sidebar toggle button */}
+        <button
+          onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+          className={`absolute top-4 z-20 bg-white border border-gray-200 rounded-full p-1.5 shadow-sm hover:bg-gray-50 transition-all duration-300 ${
+            sidebarCollapsed ? "right-4" : "right-[392px]"
+          }`}
+          title={sidebarCollapsed ? "Show debug panel" : "Hide debug panel"}
+        >
+          {sidebarCollapsed ? (
+            <ChevronLeft size={16} className="text-gray-500" />
+          ) : (
+            <ChevronRight size={16} className="text-gray-500" />
+          )}
+        </button>
+
+        {/* Right sidebar - Settings + Event Log */}
+        <section
+          className={`absolute top-0 w-[380px] right-0 bottom-0 flex flex-col border-l border-gray-200 bg-white transition-transform duration-300 ${
+            sidebarCollapsed ? "translate-x-full" : "translate-x-0"
+          }`}
+        >
+          <div className="p-4 border-b border-gray-200">
+            <ToolPanel
+              isSessionActive={isSessionActive}
+              languageA={languageA}
+              languageB={languageB}
+              translations={translations}
+            />
+          </div>
+          <div className="flex-1 p-4 overflow-y-auto">
+            <h3 className="text-sm font-bold text-gray-500 mb-2">
+              Debug Events
+            </h3>
+            <EventLog events={events} />
+          </div>
         </section>
       </main>
     </>

--- a/client/components/Button.jsx
+++ b/client/components/Button.jsx
@@ -1,8 +1,8 @@
-export default function Button({ icon, children, onClick, className }) {
+export default function Button({ icon, children, className, ...props }) {
   return (
     <button
       className={`bg-gray-800 text-white rounded-full p-4 flex items-center gap-1 hover:opacity-90 ${className}`}
-      onClick={onClick}
+      {...props}
     >
       {icon}
       {children}

--- a/client/components/ConversationTimeline.jsx
+++ b/client/components/ConversationTimeline.jsx
@@ -1,0 +1,264 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+
+function TimelineEntry({ entry, isLatest, index, total, languageA, languageB }) {
+  const opacity = Math.max(0.4, 0.4 + ((index + 1) / total) * 0.6);
+  const isPersonA = entry.speaker === "A";
+
+  // Get flag emoji based on language
+  const getFlag = (lang) => {
+    const flags = {
+      English: "🇺🇸",
+      Korean: "🇰🇷",
+      Spanish: "🇪🇸",
+      French: "🇫🇷",
+      German: "🇩🇪",
+      Japanese: "🇯🇵",
+      Chinese: "🇨🇳",
+      Portuguese: "🇧🇷",
+      Italian: "🇮🇹",
+      Russian: "🇷🇺",
+    };
+    return flags[lang] || "🌐";
+  };
+
+  return (
+    <div className="relative" style={{ opacity }}>
+      {isPersonA ? (
+        // Person A speaks (Left side)
+        <>
+          {/* Spoken (Left) */}
+          <div className="relative mb-6">
+            <div className="flex items-start">
+              <div className="w-[calc(50%-16px)] flex justify-end pr-8">
+                <div
+                  className={`relative w-full max-w-sm ${isLatest ? "scale-105" : ""} transition-all duration-300`}
+                >
+                  <div className="flex items-center justify-end gap-2 mb-2">
+                    <span className="text-xs text-gray-500">
+                      {getFlag(languageA)} Person A
+                    </span>
+                    <span className="px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-bold uppercase tracking-wide">
+                      Spoken
+                    </span>
+                  </div>
+                  <div
+                    className={`p-4 rounded-2xl rounded-tr-sm shadow-sm border-2 ${isLatest ? "bg-blue-50 border-blue-300 shadow-lg" : "bg-white border-blue-100"}`}
+                  >
+                    <p
+                      className={`text-right text-gray-900 leading-relaxed ${isLatest ? "text-lg font-medium" : "text-sm"}`}
+                    >
+                      {entry.sourceText}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="absolute left-1/2 top-8 -translate-x-1/2 z-10">
+                <div
+                  className={`w-4 h-4 rounded-full border-4 border-white shadow-sm ${isLatest ? "bg-blue-500 ring-4 ring-blue-200" : "bg-blue-300"}`}
+                />
+              </div>
+
+              <div className="w-[calc(50%-16px)]" />
+            </div>
+          </div>
+
+          {/* Translated (Right) */}
+          <div className="relative">
+            <div className="flex items-start">
+              <div className="w-[calc(50%-16px)]" />
+
+              <div className="absolute left-1/2 top-8 -translate-x-1/2 z-10">
+                <div
+                  className={`w-4 h-4 rounded-full border-4 border-white shadow-sm ${isLatest ? "bg-gray-400 ring-4 ring-gray-200" : "bg-gray-300"}`}
+                />
+              </div>
+
+              <div className="w-[calc(50%-16px)] flex justify-start pl-8">
+                <div
+                  className={`relative w-full max-w-sm ${isLatest ? "scale-105" : ""} transition-all duration-300`}
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs font-bold uppercase tracking-wide">
+                      Translated
+                    </span>
+                    <span className="text-xs text-gray-400">
+                      {getFlag(languageB)} for Person B
+                    </span>
+                  </div>
+                  <div
+                    className={`p-4 rounded-2xl rounded-tl-sm shadow-sm border-2 ${isLatest ? "bg-gray-50 border-gray-300 shadow-lg" : "bg-white border-gray-100"}`}
+                  >
+                    <p
+                      className={`text-left text-gray-700 leading-relaxed ${isLatest ? "text-lg" : "text-sm"}`}
+                    >
+                      {entry.translatedText}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </>
+      ) : (
+        // Person B speaks (Right side)
+        <>
+          {/* Spoken (Right) */}
+          <div className="relative mb-6">
+            <div className="flex items-start">
+              <div className="w-[calc(50%-16px)]" />
+
+              <div className="absolute left-1/2 top-8 -translate-x-1/2 z-10">
+                <div
+                  className={`w-4 h-4 rounded-full border-4 border-white shadow-sm ${isLatest ? "bg-green-500 ring-4 ring-green-200" : "bg-green-300"}`}
+                />
+              </div>
+
+              <div className="w-[calc(50%-16px)] flex justify-start pl-8">
+                <div
+                  className={`relative w-full max-w-sm ${isLatest ? "scale-105" : ""} transition-all duration-300`}
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs font-bold uppercase tracking-wide">
+                      Spoken
+                    </span>
+                    <span className="text-xs text-gray-500">
+                      {getFlag(languageB)} Person B
+                    </span>
+                  </div>
+                  <div
+                    className={`p-4 rounded-2xl rounded-tl-sm shadow-sm border-2 ${isLatest ? "bg-green-50 border-green-300 shadow-lg" : "bg-white border-green-100"}`}
+                  >
+                    <p
+                      className={`text-left text-gray-900 leading-relaxed ${isLatest ? "text-lg font-medium" : "text-sm"}`}
+                    >
+                      {entry.sourceText}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Translated (Left) */}
+          <div className="relative">
+            <div className="flex items-start">
+              <div className="w-[calc(50%-16px)] flex justify-end pr-8">
+                <div
+                  className={`relative w-full max-w-sm ${isLatest ? "scale-105" : ""} transition-all duration-300`}
+                >
+                  <div className="flex items-center justify-end gap-2 mb-2">
+                    <span className="text-xs text-gray-400">
+                      {getFlag(languageA)} for Person A
+                    </span>
+                    <span className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded text-xs font-bold uppercase tracking-wide">
+                      Translated
+                    </span>
+                  </div>
+                  <div
+                    className={`p-4 rounded-2xl rounded-tr-sm shadow-sm border-2 ${isLatest ? "bg-gray-50 border-gray-300 shadow-lg" : "bg-white border-gray-100"}`}
+                  >
+                    <p
+                      className={`text-right text-gray-700 leading-relaxed ${isLatest ? "text-lg" : "text-sm"}`}
+                    >
+                      {entry.translatedText}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="absolute left-1/2 top-8 -translate-x-1/2 z-10">
+                <div
+                  className={`w-4 h-4 rounded-full border-4 border-white shadow-sm ${isLatest ? "bg-gray-400 ring-4 ring-gray-200" : "bg-gray-300"}`}
+                />
+              </div>
+
+              <div className="w-[calc(50%-16px)]" />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function ConversationTimeline({
+  translations,
+  languageA,
+  languageB,
+}) {
+  const scrollRef = useRef(null);
+  const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
+
+  // Check if user is near bottom (within 100px)
+  const handleScroll = useCallback(() => {
+    if (scrollRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+      const isNearBottom = scrollHeight - scrollTop - clientHeight < 100;
+      setShouldAutoScroll(isNearBottom);
+    }
+  }, []);
+
+  // Auto-scroll to latest entry only if user hasn't scrolled up
+  useEffect(() => {
+    if (scrollRef.current && shouldAutoScroll) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }, [translations, shouldAutoScroll]);
+
+  if (translations.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center text-gray-500">
+        <p>Start speaking to see translations...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={scrollRef} className="h-full overflow-y-auto" onScroll={handleScroll}>
+      <div className="mb-12">
+        {/* Timeline Header */}
+        <div className="flex justify-between items-center mb-8 px-4">
+          <h2 className="text-sm font-medium text-gray-600">
+            conversation timeline
+          </h2>
+          <div className="flex gap-4 text-xs">
+            <div className="flex items-center gap-1.5">
+              <div className="px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs font-medium">
+                PERSON A
+              </div>
+              <span className="text-gray-500">{languageA} Speaker</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <div className="px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs font-medium">
+                PERSON B
+              </div>
+              <span className="text-gray-500">{languageB} Speaker</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Timeline Container */}
+        <div className="relative px-4">
+          {/* Center Line */}
+          <div className="absolute left-1/2 top-0 bottom-0 w-0.5 bg-gray-200 -translate-x-1/2" />
+
+          {/* Timeline Items */}
+          <div className="space-y-12">
+            {translations.map((entry, index) => (
+              <TimelineEntry
+                key={entry.id}
+                entry={entry}
+                isLatest={index === translations.length - 1}
+                index={index}
+                total={translations.length}
+                languageA={languageA}
+                languageB={languageB}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/SessionControls.jsx
+++ b/client/components/SessionControls.jsx
@@ -1,9 +1,42 @@
-import { useState } from "react";
-import { CloudLightning, CloudOff, MessageSquare } from "react-feather";
+import { useState, useEffect } from "react";
+import { CloudLightning, CloudOff, Mic } from "react-feather";
 import Button from "./Button";
 
-function SessionStopped({ startSession }) {
+const LANGUAGES = [
+  "English",
+  "Korean",
+  "Spanish",
+  "French",
+  "German",
+  "Japanese",
+  "Chinese",
+  "Portuguese",
+  "Italian",
+  "Russian",
+];
+
+function SessionStopped({
+  startSession,
+  languageA,
+  setLanguageA,
+  languageB,
+  setLanguageB,
+  inputMode,
+  setInputMode,
+  apiKey,
+  setApiKey,
+  isEditingKey,
+  setIsEditingKey,
+}) {
   const [isActivating, setIsActivating] = useState(false);
+  const [keyInput, setKeyInput] = useState(apiKey);
+
+  // Sync keyInput when entering edit mode
+  useEffect(() => {
+    if (isEditingKey) {
+      setKeyInput(apiKey);
+    }
+  }, [isEditingKey, apiKey]);
 
   function handleStartSession() {
     if (isActivating) return;
@@ -12,8 +45,108 @@ function SessionStopped({ startSession }) {
     startSession();
   }
 
+  function handleKeySubmit(e) {
+    e.preventDefault();
+    if (keyInput.trim()) {
+      setApiKey(keyInput.trim());
+      setIsEditingKey(false);
+    }
+  }
+
+  if (!apiKey || isEditingKey) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full h-full gap-3">
+        <p className="text-gray-500 text-sm">
+          {isEditingKey ? "Update your API key" : "Enter your OpenAI API key to get started"}
+        </p>
+        <form onSubmit={handleKeySubmit} className="flex items-center gap-2 w-full max-w-md">
+          <input
+            type="password"
+            placeholder="OpenAI API Key (sk-...)"
+            value={keyInput}
+            onChange={(e) => setKeyInput(e.target.value)}
+            className="border border-gray-200 rounded-lg p-2 flex-1 text-sm"
+            autoFocus
+          />
+          <button
+            type="submit"
+            className="bg-gray-800 text-white rounded-lg px-4 py-2 text-sm hover:bg-gray-700"
+          >
+            Save
+          </button>
+          {isEditingKey && (
+            <button
+              type="button"
+              onClick={() => {
+                setKeyInput(apiKey);
+                setIsEditingKey(false);
+              }}
+              className="text-gray-500 text-sm hover:text-gray-700"
+            >
+              Cancel
+            </button>
+          )}
+        </form>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex items-center justify-center w-full h-full">
+    <div className="flex flex-col items-center justify-center w-full h-full gap-3">
+      {/* Language Selection */}
+      <div className="flex items-center gap-4">
+        <select
+          value={languageA}
+          onChange={(e) => setLanguageA(e.target.value)}
+          className="border border-gray-200 rounded-lg p-2 bg-white"
+        >
+          {LANGUAGES.map((lang) => (
+            <option key={lang} value={lang}>
+              {lang}
+            </option>
+          ))}
+        </select>
+        <span className="text-gray-500 text-lg">↔</span>
+        <select
+          value={languageB}
+          onChange={(e) => setLanguageB(e.target.value)}
+          className="border border-gray-200 rounded-lg p-2 bg-white"
+        >
+          {LANGUAGES.map((lang) => (
+            <option key={lang} value={lang}>
+              {lang}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Input Mode Toggle */}
+      <div className="flex items-center gap-4 text-sm">
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="radio"
+            name="inputMode"
+            value="vad"
+            checked={inputMode === "vad"}
+            onChange={() => setInputMode("vad")}
+            className="accent-blue-500"
+          />
+          <span>Voice Activity Detection</span>
+        </label>
+        <label className="flex items-center gap-2 cursor-pointer">
+          <input
+            type="radio"
+            name="inputMode"
+            value="push-to-talk"
+            checked={inputMode === "push-to-talk"}
+            onChange={() => setInputMode("push-to-talk")}
+            className="accent-blue-500"
+          />
+          <span>Push-to-Talk</span>
+        </label>
+      </div>
+
+      {/* Start Button */}
       <Button
         onClick={handleStartSession}
         className={isActivating ? "bg-gray-600" : "bg-red-600"}
@@ -25,39 +158,36 @@ function SessionStopped({ startSession }) {
   );
 }
 
-function SessionActive({ stopSession, sendTextMessage }) {
-  const [message, setMessage] = useState("");
-
-  function handleSendClientEvent() {
-    sendTextMessage(message);
-    setMessage("");
-  }
-
+function SessionActive({
+  stopSession,
+  inputMode,
+  isRecording,
+  startRecording,
+  stopRecording,
+}) {
   return (
     <div className="flex items-center justify-center w-full h-full gap-4">
-      <input
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && message.trim()) {
-            handleSendClientEvent();
-          }
-        }}
-        type="text"
-        placeholder="send a text message..."
-        className="border border-gray-200 rounded-full p-4 flex-1"
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
-      />
-      <Button
-        onClick={() => {
-          if (message.trim()) {
-            handleSendClientEvent();
-          }
-        }}
-        icon={<MessageSquare height={16} />}
-        className="bg-blue-400"
-      >
-        send text
-      </Button>
+      {inputMode === "push-to-talk" && (
+        <Button
+          onMouseDown={startRecording}
+          onMouseUp={stopRecording}
+          onMouseLeave={stopRecording}
+          onTouchStart={startRecording}
+          onTouchEnd={stopRecording}
+          className={isRecording ? "bg-red-600" : "bg-blue-500"}
+          icon={<Mic height={16} />}
+        >
+          {isRecording ? "Recording..." : "Hold to Talk"}
+        </Button>
+      )}
+
+      {inputMode === "vad" && (
+        <div className="text-gray-500 flex items-center gap-2 bg-green-50 border border-green-200 rounded-full px-4 py-2">
+          <Mic height={16} className="text-green-500" />
+          <span className="text-green-700">Listening...</span>
+        </div>
+      )}
+
       <Button onClick={stopSession} icon={<CloudOff height={16} />}>
         disconnect
       </Button>
@@ -68,22 +198,45 @@ function SessionActive({ stopSession, sendTextMessage }) {
 export default function SessionControls({
   startSession,
   stopSession,
-  sendClientEvent,
-  sendTextMessage,
-  serverEvents,
   isSessionActive,
+  languageA,
+  setLanguageA,
+  languageB,
+  setLanguageB,
+  inputMode,
+  setInputMode,
+  isRecording,
+  startRecording,
+  stopRecording,
+  apiKey,
+  setApiKey,
+  isEditingKey,
+  setIsEditingKey,
 }) {
   return (
     <div className="flex gap-4 border-t-2 border-gray-200 h-full rounded-md">
       {isSessionActive ? (
         <SessionActive
           stopSession={stopSession}
-          sendClientEvent={sendClientEvent}
-          sendTextMessage={sendTextMessage}
-          serverEvents={serverEvents}
+          inputMode={inputMode}
+          isRecording={isRecording}
+          startRecording={startRecording}
+          stopRecording={stopRecording}
         />
       ) : (
-        <SessionStopped startSession={startSession} />
+        <SessionStopped
+          startSession={startSession}
+          languageA={languageA}
+          setLanguageA={setLanguageA}
+          languageB={languageB}
+          setLanguageB={setLanguageB}
+          inputMode={inputMode}
+          setInputMode={setInputMode}
+          apiKey={apiKey}
+          setApiKey={setApiKey}
+          isEditingKey={isEditingKey}
+          setIsEditingKey={setIsEditingKey}
+        />
       )}
     </div>
   );

--- a/client/components/ToolPanel.jsx
+++ b/client/components/ToolPanel.jsx
@@ -1,131 +1,31 @@
-import { useEffect, useState } from "react";
-
-const functionDescription = `
-Call this function when a user asks for a color palette.
-`;
-
-const sessionUpdate = {
-  type: "session.update",
-  session: {
-    type: "realtime",
-    tools: [
-      {
-        type: "function",
-        name: "display_color_palette",
-        description: functionDescription,
-        parameters: {
-          type: "object",
-          strict: true,
-          properties: {
-            theme: {
-              type: "string",
-              description: "Description of the theme for the color scheme.",
-            },
-            colors: {
-              type: "array",
-              description: "Array of five hex color codes based on the theme.",
-              items: {
-                type: "string",
-                description: "Hex color code",
-              },
-            },
-          },
-          required: ["theme", "colors"],
-        },
-      },
-    ],
-    tool_choice: "auto",
-  },
-};
-
-function FunctionCallOutput({ functionCallOutput }) {
-  const { theme, colors } = JSON.parse(functionCallOutput.arguments);
-
-  const colorBoxes = colors.map((color) => (
-    <div
-      key={color}
-      className="w-full h-16 rounded-md flex items-center justify-center border border-gray-200"
-      style={{ backgroundColor: color }}
-    >
-      <p className="text-sm font-bold text-black bg-slate-100 rounded-md p-2 border border-black">
-        {color}
-      </p>
-    </div>
-  ));
-
-  return (
-    <div className="flex flex-col gap-2">
-      <p>Theme: {theme}</p>
-      {colorBoxes}
-      <pre className="text-xs bg-gray-100 rounded-md p-2 overflow-x-auto">
-        {JSON.stringify(functionCallOutput, null, 2)}
-      </pre>
-    </div>
-  );
-}
-
 export default function ToolPanel({
   isSessionActive,
-  sendClientEvent,
-  events,
+  languageA,
+  languageB,
+  translations,
 }) {
-  const [functionAdded, setFunctionAdded] = useState(false);
-  const [functionCallOutput, setFunctionCallOutput] = useState(null);
-
-  useEffect(() => {
-    if (!events || events.length === 0) return;
-
-    const firstEvent = events[events.length - 1];
-    if (!functionAdded && firstEvent.type === "session.created") {
-      sendClientEvent(sessionUpdate);
-      setFunctionAdded(true);
-    }
-
-    const mostRecentEvent = events[0];
-    if (
-      mostRecentEvent.type === "response.done" &&
-      mostRecentEvent.response.output
-    ) {
-      mostRecentEvent.response.output.forEach((output) => {
-        if (
-          output.type === "function_call" &&
-          output.name === "display_color_palette"
-        ) {
-          setFunctionCallOutput(output);
-          setTimeout(() => {
-            sendClientEvent({
-              type: "response.create",
-              response: {
-                instructions: `
-                ask for feedback about the color palette - don't repeat 
-                the colors, just ask if they like the colors.
-              `,
-              },
-            });
-          }, 500);
-        }
-      });
-    }
-  }, [events]);
-
-  useEffect(() => {
-    if (!isSessionActive) {
-      setFunctionAdded(false);
-      setFunctionCallOutput(null);
-    }
-  }, [isSessionActive]);
-
   return (
     <section className="h-full w-full flex flex-col gap-4">
-      <div className="h-full bg-gray-50 rounded-md p-4">
-        <h2 className="text-lg font-bold">Color Palette Tool</h2>
-        {isSessionActive
-          ? (
-            functionCallOutput
-              ? <FunctionCallOutput functionCallOutput={functionCallOutput} />
-              : <p>Ask for advice on a color palette...</p>
-          )
-          : <p>Start the session to use this tool...</p>}
+      <div className="bg-gray-50 rounded-md p-4">
+        <h2 className="text-lg font-bold mb-2">Translation Settings</h2>
+        {isSessionActive ? (
+          <div className="space-y-2">
+            <p>
+              <strong>Languages:</strong> {languageA} ↔ {languageB}
+            </p>
+            <p>
+              <strong>Translations:</strong> {translations.length}
+            </p>
+            <p className="text-sm text-gray-500 mt-4">
+              Speak in either language. The app will detect which language
+              you&apos;re speaking and translate to the other.
+            </p>
+          </div>
+        ) : (
+          <p className="text-gray-500">
+            Select your languages and start a session to begin translating.
+          </p>
+        )}
       </div>
     </section>
   );

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import "dotenv/config";
 
 const app = express();
 app.use(express.text());
+app.use(express.json());
 const port = process.env.PORT || 3000;
 const apiKey = process.env.OPENAI_API_KEY;
 
@@ -15,13 +16,27 @@ const vite = await createViteServer({
 });
 app.use(vite.middlewares);
 
-const sessionConfig = JSON.stringify({
+// Session configuration for transcription-focused realtime session
+// Using /v1/realtime/client_secrets endpoint (requires session wrapper)
+const getSessionConfig = (turnDetectionType = "server_vad") => ({
   session: {
     type: "realtime",
     model: "gpt-realtime",
+    instructions: "Transcribe audio. Do not respond with audio.",
     audio: {
-      output: {
-        voice: "marin",
+      input: {
+        transcription: {
+          model: "whisper-1",
+        },
+        turn_detection:
+          turnDetectionType === "none"
+            ? null
+            : {
+                type: "server_vad",
+                threshold: 0.5,
+                prefix_padding_ms: 300,
+                silence_duration_ms: 200,
+              },
       },
     },
   },
@@ -51,24 +66,73 @@ app.post("/session", async (req, res) => {
 
 // API route for ephemeral token generation
 app.get("/token", async (req, res) => {
+  const turnDetection = req.query.turnDetection || "server_vad";
+  const clientApiKey = req.headers["x-api-key"];
+
+  if (!clientApiKey) {
+    return res.status(400).json({ error: "API key required" });
+  }
+
   try {
     const response = await fetch(
       "https://api.openai.com/v1/realtime/client_secrets",
       {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${apiKey}`,
+          Authorization: `Bearer ${clientApiKey}`,
           "Content-Type": "application/json",
         },
-        body: sessionConfig,
+        body: JSON.stringify(getSessionConfig(turnDetection)),
       },
     );
 
     const data = await response.json();
+    console.log("OpenAI session response:", JSON.stringify(data, null, 2));
     res.json(data);
   } catch (error) {
     console.error("Token generation error:", error);
     res.status(500).json({ error: "Failed to generate token" });
+  }
+});
+
+// API route for translation
+app.post("/translate", async (req, res) => {
+  const { text, languageA, languageB } = req.body;
+  const clientApiKey = req.headers["x-api-key"];
+
+  if (!clientApiKey) {
+    return res.status(400).json({ error: "API key required" });
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${clientApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          {
+            role: "system",
+            content: `You are a translation assistant. Given text, detect if it's in ${languageA} or ${languageB}, then translate to the other language. Respond in JSON format only: {"detectedLanguage": "...", "sourceText": "...", "translatedText": "...", "targetLanguage": "..."}`,
+          },
+          {
+            role: "user",
+            content: text,
+          },
+        ],
+        response_format: { type: "json_object" },
+      }),
+    });
+
+    const data = await response.json();
+    const translation = JSON.parse(data.choices[0].message.content);
+    res.json(translation);
+  } catch (error) {
+    console.error("Translation error:", error);
+    res.status(500).json({ error: "Failed to translate" });
   }
 });
 


### PR DESCRIPTION
## Summary
- Convert the realtime console from conversational AI to a **transcription-first translation app**
- Uses Whisper for speech-to-text with auto language detection
- Translates between two user-selected languages via Chat Completions API (gpt-4o-mini)
- New timeline UI showing original speech and translations for both speakers
- Support for VAD (voice activity detection) and push-to-talk input modes

## Features
- **Client-side API key**: Users provide their own OpenAI key (stored in localStorage)
- **Language pair selection**: Choose any two languages from the supported list
- **Collapsible debug sidebar**: Toggle to show/hide event log
- **Smart auto-scroll**: Timeline scrolls with new messages but pauses when user scrolls up
- **Push-to-talk**: Hold button to record, release to transcribe

## Test plan
- [ ] Enter API key and verify it persists on refresh
- [ ] Select language pair and start session with VAD mode
- [ ] Speak in one language, verify transcription and translation appear
- [ ] Test push-to-talk mode
- [ ] Verify sidebar collapse/expand works
- [ ] Test auto-scroll behavior (should pause when scrolled up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)